### PR TITLE
Multiple vec fixes that are useful to implement canvas_ity. 

### DIFF
--- a/source/numem/string.d
+++ b/source/numem/string.d
@@ -207,16 +207,16 @@ public:
     /**
         Returns C string
     */
-    inout(T)* toCStringi() inout {
-        return cast(inout(T)*)this.vec_.idata();
+    immutable(T)* toCString() immutable {
+        return this.vec_.data();
     }
 
     /**
         Returns C string
     */
     @trusted
-    const(T)* toCString() {
-        return cast(const(T)*)this.vec_.data();
+    const(T)* toCString() const {
+        return this.vec_.data();
     }
 
     /**
@@ -359,7 +359,7 @@ public:
         import core.stdc.string : strncmp;
         if (this.size() < s.size()) return -1;
         if (this.size() > s.size()) return 1;
-        return strncmp(this.toCStringi(), s.toCStringi(), this.size());
+        return strncmp(this.toCString(), s.toCString(), this.size());
     }
 
     /**


### PR DESCRIPTION
I found quite a bit of oddities in vector still.

- Remove bizzarre idata() method, normally inout should not contaminate identifiers. Fixed that in strings, I supposed the goal was to not return mutable C string from numem string
- vec.ptr() as alias to vec.data(), which is now inout. It fixed `ref auto opOpAssign(string op = "~")(vector!T other)` that uses `other.ptr`
- `vec.length` as alias of `vec.size`
- compiler suggested that `vec.opDollar` be `const` or `inout`
- `clear()` and `remove()` will clean-up items in reverse manner just like the destructor, and only if not a basic type.
- `ref inout(T) opIndex`. else you can't index vector fields in const methods.

- BREAKING `vec.remove()` is fixed (it was not possible to remove zero items with its API without crashing) and is now "delete [start, end)" instead of "delete [start, end]". Changed error recovery that swaps start and end to assertion. That makes the functions more similar in contract to c++ `std::vector::erase()` and a bit more expected to me. IF the contract doesn't change, at least it should say plainly that this will crash if no items are removed.