### PR TITLE
Fix nogc_trydelete for extern(C++) classes, would cause build error.

### DIFF
--- a/source/numem/lifetime.d
+++ b/source/numem/lifetime.d
@@ -232,7 +232,8 @@ void nogc_delete(T, bool doFree=true)(ref T obj_) @trusted {
 */
 bool nogc_trydelete(T, bool doFree=true)(ref T obj_) @trusted nothrow {
     static if (isCPP!T) {
-        assumeNoThrowNoGC((ref T obj_) => cpp_delete(obj_), obj_);
+        assumeNoThrowNoGC((ref T obj_) => cpp_delete!T(obj_), obj_);
+        return true;
     } else {
         try {
             nogc_delete(obj_);


### PR DESCRIPTION
The problem this is fixing is: "you can't `nogc_trydelete` an `extern(C++)` class."

To reproduce before fix:
```d
unittest
{
    extern(C++) static class A
    {
        int b;
    }

    A a = nogc_trynew!A();
    nogc_trydelete!A(a);
}
```

The issue was: instantiating wrong template + no bool result. Hereby assuming cpp_delete never fails.