### PR TITLE
Fix printf signature. 

### DIFF
--- a/source/numem/core/hooks.d
+++ b/source/numem/core/hooks.d
@@ -172,7 +172,7 @@ export
 extern(C)
 void nu_fatal(const(char)[] errMsg) @nogc nothrow @system pure @weak {
     pragma(mangle, "printf")
-    extern extern(C) void printf(const(char)*, ...) @nogc nothrow @system pure;
+    extern extern(C) int printf(const(char)*, ...) @nogc nothrow @system pure;
     pragma(mangle, "abort")
     extern extern(C) void abort() @nogc nothrow @system pure;
 


### PR DESCRIPTION
Linux linker is complaining about two functions mangled with same name but with different signatures. 

(This can be reproduced with dplug-build --redub --final on a Dplug plugin, using a recent redub and dplug-build). 

I don't think this fix has adverse effect, as on Linux and C standard all printf functions seem to return int.

Precisely the one in core.stdc.stdio and nu_fatal are clashing.