### PR TITLE
nu_bsf was returning a wrong value in the LDC path

### DIFF
--- a/source/numem/core/math.d
+++ b/source/numem/core/math.d
@@ -132,7 +132,7 @@ T nu_bsf(T)(T value) @nogc nothrow @trusted pure
 if (__traits(isIntegral, T)) {
     version(LDC) {
         import ldc.intrinsics : llvm_cttz;
-        return cast(int)(value.sizeof * 8 - 1 - llvm_cttz(value, true));
+        return cast(int)(llvm_cttz(value, true));
     } else {
         
         // Slow software implementation.


### PR DESCRIPTION
Explanation: The 'llvm.cttz' intrinsic counts the trailing (least significant) zeros in a variable. This number of zeroes is already the index of the first least significant set bit. Since nu_bsf(0) is UB, no edge case.

This helps getting the intel-intrinsics test suite working on nurt+wasm32